### PR TITLE
fix alternate root for /usr/bin/env

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//usr/bin/env go run "$0" "$@" ; exit "$?"
+///usr/bin/env go run "$0" "$@" ; exit "$?"
 package main
 
 import "fmt"


### PR DESCRIPTION
In POSIX, two slashes (`//`) is the alternate root (this is why `cd //` keeps your pwd as two slashes) which can have implementation-defined contents.

But we can solve this problem with three slashes.

From https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html :

A pathname consisting of a single <slash> shall resolve to the root directory of the process. A null pathname shall not be successfully resolved. If a pathname begins with two successive <slash> characters, the first component following the leading <slash> characters may be interpreted in an implementation-defined manner, although more than two leading <slash> characters shall be treated as a single <slash> character.